### PR TITLE
ignore files inside inst/scratch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 packrat/lib*/
 *rsconnect*
 .direnv*/
-inst/scratch/*
+scratch

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 packrat/lib*/
 *rsconnect*
 .direnv*/
+inst/scratch/*


### PR DESCRIPTION
The files inside of inst/scratch should be ignored again on the master branch, it's causing problems for me switching between master (with an empty scratch folder) and the species_comments branch (with a not empty scratch folder) where git keeps trying to delete the scratch folder and failing.

This is the error I get:
$ git checkout master
Deletion of directory 'inst/scratch' failed. Should I try again? (y/n) n

I'd like to merge the new stop level folder location into my species_comments branch from main, this is also causing a problem there. I had to abort a merge bc it was suggesting deleting everything in scratch (where I'm keeping my draft workflow, which will eventually get cleaned up when I'm done with the branch) 

I think this should fix it? Let me know if there's a better way to do this, and if "inst/scratch/*" is the best way to add to the gitignore or not