### PR TITLE
Add infastructure for testthat

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,3 +25,6 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.3.1
+Suggests: 
+    testthat (>= 3.0.0)
+Config/testthat/edition: 3

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,12 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/tests.html
+# * https://testthat.r-lib.org/reference/test_package.html#special-files
+
+library(testthat)
+library(mbbs)
+
+test_check("mbbs")

--- a/tests/testthat/test_import_ebird_data.R
+++ b/tests/testthat/test_import_ebird_data.R
@@ -4,6 +4,7 @@
 
 test_that("get_exclusions runs",
   {
-    expect_no_error(get_exclusions("inst/excluded_submissions.yml"))
+    x <- system.file("excluded_submissions.yml", package = "mbbs")
+    expect_no_error(get_exclusions(x))
   }
 )

--- a/tests/testthat/test_import_ebird_data.R
+++ b/tests/testthat/test_import_ebird_data.R
@@ -1,0 +1,9 @@
+# Testing functions in
+# import_ebird_data.R
+
+
+test_that("get_exclusions runs",
+  {
+    expect_no_error(get_exclusions("../../inst/excluded_submissions.yml"))
+  }
+)

--- a/tests/testthat/test_import_ebird_data.R
+++ b/tests/testthat/test_import_ebird_data.R
@@ -4,6 +4,6 @@
 
 test_that("get_exclusions runs",
   {
-    expect_no_error(get_exclusions("../../inst/excluded_submissions.yml"))
+    expect_no_error(get_exclusions("inst/excluded_submissions.yml"))
   }
 )


### PR DESCRIPTION
This MR:

* ran `usethis::use_testthat()` to create the barebones infrastructure for `testthat`