### PR TITLE
Add 2025 precount stops, 0 bird stops

### DIFF
--- a/data/excluded_submissions.yml
+++ b/data/excluded_submissions.yml
@@ -77,3 +77,10 @@
 
 #Ali Iyoob's Orange 11, 2012 route
 - S11121959 
+
+#2025 Chatham 3 precounts
+- S251452155
+- S251452154
+- S251452153
+#2025 Durham 8 precount
+- S248200794

--- a/data/stop_deviations.yml
+++ b/data/stop_deviations.yml
@@ -46,3 +46,9 @@
   route : 3
   stops_nobirds : [12]
   stops_skipped : []
+
+- date : 2025-06-16
+  county : chatham
+  route : 3
+  stops_nobirds : [11, 12]
+  stops_skipped : []


### PR DESCRIPTION
Updated .yaml files with the stops that were precounts (3 from chatham 3, 1 from durham 8) and stops that had no birds observed (2 from chatham 3)