### PR TITLE
comment out unused log calls

### DIFF
--- a/R/mbbs.R
+++ b/R/mbbs.R
@@ -50,48 +50,6 @@ create_stop_level_counts_0 <- function(ebird, taxonomy, config = config) {
         !anyNA(df$stop_num),
         msg = "Stop data has NA values in stop_num."
       )
-
-      # Check that there are not duplicate entries with different counts
-      # LOG CALL REMOVED: we won't be updating/modifying these data further.
-      # Surveys with differing counts from different sources are assigned the 'true'
-      # values based on handling detailed in docs/data_pipeline.
-      # df |>
-      #   dplyr::group_by(year, route, stop_num, common_name) |>
-      #   dplyr::summarise(
-      #     n = dplyr::n(),
-      #     distinctcounts = n_distinct(count),
-      #     sources = paste(source, collapse = " & ")
-      #   ) |>
-      #   dplyr::filter(n > 1 & distinctcounts > 1) |>
-      #   (\(x) {
-      #     logger::log_error(
-      #       paste(
-      #         "Route {x$route}-{x$stop_num} has multiple entries",
-      #         "with differing counts",
-      #         "for {x$common_name}",
-      #         "in {x$year} coming from {x$sources}"
-      #       )
-      #     )
-      #   })()
-
-      # Log number of duplicate entries with the same count
-      # LOG CALL REMOVED: we won't be updating/modifying these data further.
-      # No longer need to know how many stop-level data entries had duplicates
-      # from two or more sources.
-      #   df |>
-      #     dplyr::distinct(year, route, stop_num, common_name, count,
-      #       .keep_all = TRUE
-      #     ) |>
-      #     (\(x) {
-      #       logger::log_info(
-      #         paste(
-      #           "Stop-level data contains",
-      #           "{nrow(df) - nrow(x)} duplicated observations",
-      #           "(same count, different sources)"
-      #         )
-      #       )
-      #     })()
-      #
       df
     })()
 }
@@ -223,23 +181,7 @@ create_route_level_counts_0 <- function(ebird, stop_level_data, taxonomy, config
         )
       )
       x
-    })() |>
-    dplyr::filter(diff != 0) #|>
-  # LOG CALL REMOVED: we won't be updating/modifying these data further.
-  # Surveys with differing counts from different sources are assigned the 'true'
-  # values based on handling detailed in docs/data_pipeline.
-  # (\(x) {
-  #  if (nrow(x) > 0) {
-  #    logger::log_warn(
-  #      paste(
-  #        "{x$year}-{x$route} had",
-  #        "{x$scount} {x$common_name} aggregrated in stop_level",
-  #        "{x$source}",
-  #        "but {x$rcount} in the ebird checklist."
-  #      )
-  #    )
-  #  }
-  # })()
+    })()
 
   logger::log_trace("Getting ebird data without stop-level information")
   ebird_no_stop <- ebird |>

--- a/R/stop-level_obs_comments.R
+++ b/R/stop-level_obs_comments.R
@@ -154,27 +154,11 @@ pad_or_truncate <- \(x, subid, common_name) {
   `if`(
     length(x) == 19,
     {
-      # LOG CALL REMOVED: we won't be updating/modifying these data further, no
-      # longer need to give error when obs details only parse to length 19.
-      # all cases that could be fixed have been handled.
-      #  logger::log_error(
-      #    "{subid} {common_name}: observation details parsed to length == 19."
-      #  )
-      #  logger::log_trace("{subid} {common_name}: 0 count added add at stop 20")
       c(x, "")
     },
     `if`(
       length(x) > 20,
       {
-        # LOG CALL REMOVED: we won't be updating/modifying these data further, no
-        # longer need to give error obs details > length 20.
-        # all cases that could be fixed have been handled.
-        # logger::log_error(
-        #  "{subid} {common_name}: observation details parsed to length > 20."
-        # )
-        # logger::log_trace(
-        #  "{subid} {common_name}: counts truncated at first 20 stops"
-        # )
         x[1:20]
       },
       x


### PR DESCRIPTION
Commented out the the WARN and ERROR log calls relating to stop-level data. They're not going to change, and we've already got a system in place to set the 'true' values of conflicting counts from two different stop-level data sources. This closes #161 